### PR TITLE
Add support for optional depends and enable them by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,13 @@ list(APPEND superbuild_project_roots
 # set the default arguments used for "git clone"
 set(_git_clone_arguments_default --progress)
 
-# build F3D by default
+# build F3D and all its optional dependencies by default
 set(_superbuild_default_f3d ON)
+set(_superbuild_default_alembic ON)
+set(_superbuild_default_assimp ON)
+set(_superbuild_default_occt ON)
+set(_superbuild_default_ospray ON)
+set(_superbuild_default_pybind11 ON)
 
 if (NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/superbuild/CMakeLists.txt")
   message(FATAL_ERROR "It appears as though the superbuild infrastructure "

--- a/projects/f3d.cmake
+++ b/projects/f3d.cmake
@@ -1,18 +1,19 @@
 superbuild_add_project(f3d
   LICENSE_FILES
     LICENSE
-  DEPENDS vtk pybind11 alembic assimp occt
+  DEPENDS vtk
+  DEPENDS_OPTIONAL pybind11 alembic assimp occt
   CMAKE_ARGS
     -Werror=dev
     -Werror=deprecated
     --warn-uninitialized
     -DF3D_STRICT_BUILD=ON
     -DF3D_MODULE_EXTERNAL_RENDERING=ON
-    -DF3D_MODULE_OCCT=ON
-    -DF3D_MODULE_ASSIMP=ON
-    -DF3D_MODULE_ALEMBIC=ON
-    -DF3D_MODULE_RAYTRACING=ON
-    -DF3D_PYTHON_BINDINGS=ON
+    -DF3D_MODULE_OCCT:BOOL=${occt_enabled}
+    -DF3D_MODULE_ASSIMP:BOOL=${assimp_enabled}
+    -DF3D_MODULE_ALEMBIC:BOOL=${alembic_enabled}
+    -DF3D_MODULE_RAYTRACING:BOOL=${ospray_enabled}
+    -DF3D_PYTHON_BINDINGS:BOOL=${pybind11_enabled}
     -DCMAKE_BUILD_TYPE=Release
     -DF3D_INSTALL_DEFAULT_CONFIGURATION_FILE=ON
     -DF3D_INSTALL_DEFAULT_CONFIGURATION_FILE_IN_PREFIX=ON

--- a/projects/vtk.cmake
+++ b/projects/vtk.cmake
@@ -1,7 +1,8 @@
 superbuild_add_project(vtk
   LICENSE_FILES
     Copyright.txt
-  DEPENDS cxx11 tbb ospray
+  DEPENDS cxx11 tbb
+  DEPENDS_OPTIONAL ospray
   CMAKE_ARGS
     -DVTK_ENABLE_LOGGING=OFF
     -DVTK_ENABLE_WRAPPING=OFF
@@ -32,5 +33,5 @@ superbuild_add_project(vtk
     -DVTK_MODULE_ENABLE_VTK_RenderingOpenGL2=YES
     -DVTK_MODULE_ENABLE_VTK_RenderingVolumeOpenGL2=YES
     -DVTK_MODULE_ENABLE_VTK_TestingCore=YES
-    -DVTK_MODULE_ENABLE_VTK_RenderingRayTracing=YES
+    -DVTK_MODULE_ENABLE_VTK_RenderingRayTracing:BOOL=${ospray_enabled}
 )

--- a/projects/vtk.cmake
+++ b/projects/vtk.cmake
@@ -1,3 +1,8 @@
+set(vtk_raytracing_enabled NO)
+if (ospray_enabled)
+  set(vtk_raytracing_enabled YES)
+endif ()
+
 superbuild_add_project(vtk
   LICENSE_FILES
     Copyright.txt
@@ -33,5 +38,5 @@ superbuild_add_project(vtk
     -DVTK_MODULE_ENABLE_VTK_RenderingOpenGL2=YES
     -DVTK_MODULE_ENABLE_VTK_RenderingVolumeOpenGL2=YES
     -DVTK_MODULE_ENABLE_VTK_TestingCore=YES
-    -DVTK_MODULE_ENABLE_VTK_RenderingRayTracing:BOOL=${ospray_enabled}
+    -DVTK_MODULE_ENABLE_VTK_RenderingRayTracing:STRING=${vtk_raytracing_enabled}
 )


### PR DESCRIPTION
When building locally for any reason, being able to disable optional dependencies cuts down build time drastically, making that possible while still considering that the default behavior of the fsb should be to build all dep.