### PR TITLE
Improve sccache cache mgt

### DIFF
--- a/.github/actions/f3d-superbuild/action.yml
+++ b/.github/actions/f3d-superbuild/action.yml
@@ -30,13 +30,15 @@ runs:
     shell: bash
     run: |
       echo SCCACHE_CACHE=$(sccache --show-stats | grep Local | cut -d '"' -f2) >> $GITHUB_ENV
+      echo DATE_STRING=$(date +'%Y%m%d') >> $GITHUB_ENV
       sccache --stop-server
 
   - name: Recover sccache cache
     uses: actions/cache@v3
     with:
       path: ${{env.SCCACHE_CACHE}}
-      key: sccache-cache-1-${{inputs.os}}-${{hashFiles('**/versions.cmake')}}
+      key: sccache-cache-1-${{inputs.os}}-${{env.DATE_STRING}}
+      restore-keys: sccache-cache-1-${{inputs.os}}
 
   - name: Start sccache
     shell: bash


### PR DESCRIPTION
Previously, the sccache_cache was related to version.cmake. This was an okay approach that ensured that the cache will be regenerated when we change the version of the software we package, but it was not ideal in many ways.

1. When we change the version of a software, the previous cache is still valid, just incomplete, but it could still be used to speed up that specific build
2. Certains changes to the compilation output are caused by change in other files than versions.cmake, making the cache not perfect when these change occured without regenerating the cache.

The restore-keys approach fixes that. Indeed, restore-keys will grab the *last generated* cache that match (starts with) the restore-keys pattern.

So now, each time the ci is run, the cache action will restore any cache, even for the previous day, and create a new cache for the day if not available already.

Since cache are kept for a week when not used, this means that the maximum number of caches we can have at the same time is 7*3=21, which is perfectly acceptable (roughly 2.5G, max cache size is 10G per repository), while also ensuring cache is almost as good as possible for each run *and* cache is automatically regenerated.

From the doc: https://github.com/actions/cache/pull/896/files