### PR TITLE
Recover VTK commit from F3D

### DIFF
--- a/.github/actions/f3d-superbuild/action.yml
+++ b/.github/actions/f3d-superbuild/action.yml
@@ -62,6 +62,13 @@ runs:
     shell: bash
     run: mkdir build
 
+  - name: Recover VTK version to build
+    working-directory: ${{github.workspace}}
+    shell: bash
+    run: |
+      curl -L --output vtk_commit_sha https://raw.githubusercontent.com/f3d-app/f3d/master/.github/actions/vtk_commit_sha
+      echo VTK_COMMIT_SHA=`cat ./vtk_commit_sha` >> $GITHUB_ENV
+
   - name: Configure
     working-directory: ${{github.workspace}}/build
     shell: bash
@@ -70,6 +77,8 @@ runs:
       -DCMAKE_BUILD_TYPE=Release
       -Df3d_SOURCE_SELECTION=git
       -Df3d_GIT_TAG=${{ inputs.f3d_version }}
+      -Dvtk_SOURCE_SELECTION=git
+      -Dvtk_GIT_TAG=${{ env.VTK_COMMIT_SHA }}
       -DUSE_SYSTEM_python3=ON
       -DCMAKE_C_COMPILER_LAUNCHER=sccache
       -DCMAKE_CXX_COMPILER_LAUNCHER=sccache

--- a/versions.cmake
+++ b/versions.cmake
@@ -24,12 +24,9 @@ superbuild_set_revision(draco
   URL_MD5 a0782fa8148610920bb3e91f3b8cc83c)
 
 superbuild_set_selectable_source(vtk
-  SELECT 9.2.2
-    URL     "https://www.vtk.org/files/release/9.2/VTK-9.2.2.tar.gz"
-    URL_MD5 35e80f6bb8805d1a5f995b4ee0f93718
-  SELECT commit DEFAULT
-    GIT_REPOSITORY "https://gitlab.kitware.com/vtk/vtk.git"
-    GIT_TAG        "ea2b6b5ad1516f65684eff0972a198af873ca1c1"
+  SELECT 9.2.5 DEFAULT
+    URL     "https://www.vtk.org/files/release/9.2/VTK-9.2.5.tar.gz"
+    URL_MD5 0749bd742b9a56d97099e1ab9737ccf1
   SELECT git CUSTOMIZABLE
     GIT_REPOSITORY "https://gitlab.kitware.com/vtk/vtk.git"
     GIT_TAG        "origin/master"


### PR DESCRIPTION
- FSB now builds last release of VTK by default instead of a specfic commit
- Update last release to 9.2.5
- In the CI, download and use https://raw.githubusercontent.com/f3d-app/f3d/master/.github/actions/vtk_commit_sha to select the version of VTK to build
- [x] TODO check artifact is built with expected version of VTK