### PR TITLE
Share cache between raytracing and non-raytracing

### DIFF
--- a/.github/actions/f3d-superbuild/action.yml
+++ b/.github/actions/f3d-superbuild/action.yml
@@ -37,8 +37,8 @@ runs:
     uses: actions/cache@v3
     with:
       path: ${{env.SCCACHE_CACHE}}
-      key: sccache-cache-${{inputs.raytracing_label}}-${{runner.os}}-0-${{env.DATE_STRING}}
-      restore-keys: sccache-cache-${{inputs.raytracing_label}}-${{runner.os}}-0
+      key: sccache-cache-${{runner.os}}-0-${{env.DATE_STRING}}
+      restore-keys: sccache-cache-${{runner.os}}-0
 
   - name: Start sccache
     shell: bash


### PR DESCRIPTION
We cant separate one cache per build as we may run out of space, so lets try sharing caches.