### PR TITLE
Improving python bindings deps logic

### DIFF
--- a/projects/f3d.cmake
+++ b/projects/f3d.cmake
@@ -9,6 +9,11 @@ elseif (UNIX)
   set(f3d_build_for_linux TRUE)
 endif ()
 
+set (f3d_build_python_bindings FALSE)
+if (pybind11_enabled AND python3_enabled)
+  set (f3d_build_python_bindings TRUE)
+endif ()
+
 superbuild_add_project(f3d
   BUILD_SHARED_LIBS_INDEPENDENT
   LICENSE_FILES
@@ -33,7 +38,7 @@ superbuild_add_project(f3d
     -DF3D_PLUGIN_BUILD_ASSIMP:BOOL=${assimp_enabled}
     -DF3D_PLUGIN_BUILD_DRACO:BOOL=${draco_enabled}
     -DF3D_PLUGIN_BUILD_OCCT:BOOL=${occt_enabled}
-    -DF3D_BINDINGS_PYTHON:BOOL=${pybind11_enabled}
+    -DF3D_BINDINGS_PYTHON:BOOL=${f3d_build_python_bindings}
     -DF3D_STRICT_BUILD=ON
     -DF3D_WINDOWS_GUI:BOOL=${f3d_build_for_windows}
     -DF3D_PLUGIN_OCCT_COLORING_SUPPORT=${OCCT_ENABLE_COLORING}

--- a/projects/pybind11.cmake
+++ b/projects/pybind11.cmake
@@ -1,0 +1,7 @@
+superbuild_add_project(pybind11
+  DEPENDS cxx11
+  LICENSE_FILES
+    LICENSE
+  CMAKE_ARGS
+    -DPYBIND11_TEST:BOOL=OFF
+    -DPYBIND11_NOPYTHON:BOOL=ON)


### PR DESCRIPTION
- Override common sb pybind11 with a new project that do not depend on python
- Enable F3D python bindings only when both pybind11 and python3 are enabled
- Tested locally, no CI yet