### PR TITLE
CI: limit parallel build

### DIFF
--- a/.github/actions/f3d-superbuild/action.yml
+++ b/.github/actions/f3d-superbuild/action.yml
@@ -109,7 +109,7 @@ runs:
   - name: Build
     working-directory: ${{github.workspace}}/build
     shell: bash
-    run: cmake --build . --parallel 2 --config Release
+    run: cmake --build . --config Release
 
   - name: Package
     working-directory: ${{github.workspace}}/build


### PR DESCRIPTION
Superbuild is already parallel at the project level, no need to parallel build project, especially with some project using a lot of RAM.