### PR TITLE
CI: Cleanup macos arm again

### DIFF
--- a/.github/actions/f3d-superbuild/action.yml
+++ b/.github/actions/f3d-superbuild/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'A label to enable egl rendering'
     required: false
     default: 'no-egl'
+  cpu:
+    description: 'CPU architecture to build for'
+    required: false
+    default: 'x86_64'
 
 runs:
   using: "composite"
@@ -42,8 +46,8 @@ runs:
     uses: actions/cache@v4
     with:
       path: ${{env.SCCACHE_CACHE}}
-      key: sccache-cache-${{inputs.raytracing_label}}-${{runner.os}}-${{ runner.os == 'macOS' && env.CMAKE_OSX_ARCHITECTURES || 'x86_64' }}-0-${{env.DATE_STRING}}
-      restore-keys: sccache-cache-${{inputs.raytracing_label}}-${{runner.os}}-${{ runner.os == 'macOS' && env.CMAKE_OSX_ARCHITECTURES || 'x86_64' }}-0
+      key: sccache-cache-${{inputs.raytracing_label}}-${{runner.os}}-${{inputs.cpu}}-0-${{env.DATE_STRING}}
+      restore-keys: sccache-cache-${{inputs.raytracing_label}}-${{runner.os}}-${{inputs.cpu}}-0
 
   - name: Start sccache
     shell: bash
@@ -163,7 +167,7 @@ runs:
   - name: Set CI test exception for macOS x86_64
     if: |
       runner.os == 'macOS' &&
-      env.CMAKE_OSX_ARCHITECTURES == 'x86_64'
+      inputs.cpu == 'x86_64'
     shell: bash
     run: echo "F3D_CTEST_EXCEPTIONS=(TestOCCTColoring)" >> $GITHUB_ENV
 
@@ -173,7 +177,7 @@ runs:
   - name: Set CI test exception for macOS arm64
     if: |
       runner.os == 'macOS' &&
-      env.CMAKE_OSX_ARCHITECTURES == 'arm64'
+      inputs.cpu == 'arm64'
     shell: bash
     run: echo "F3D_CTEST_EXCEPTIONS=(TestSimple)|(TestAlembic)|(TestDraco)|(TestOCCT)|(TestOCCTColoring)|(TestUSD)|(TestVDB)" >> $GITHUB_ENV
 
@@ -189,7 +193,7 @@ runs:
     uses: actions/upload-artifact@v4
     with:
       path: ./build/Testing/Temporary
-      name: f3d-superbuild-tests-artifact-${{runner.os}}-${{env.CMAKE_OSX_ARCHITECTURES}}-${{inputs.raytracing_label}}-${{inputs.egl_label}}
+      name: f3d-superbuild-tests-artifact-${{runner.os}}-${{inputs.cpu}}-${{inputs.raytracing_label}}-${{inputs.egl_label}}
 
   - name: Cleanup sccache
     working-directory: ${{github.workspace}}
@@ -201,4 +205,4 @@ runs:
     uses: actions/upload-artifact@v4
     with:
       path: ./build/F3D-*
-      name: F3D-${{runner.os}}-${{inputs.raytracing_label}}-${{inputs.egl_label == 'egl' && 'headless' || 'desktop'}}-${{ runner.os == 'macOS' && env.CMAKE_OSX_ARCHITECTURES || 'x86_64' }}
+      name: F3D-${{runner.os}}-${{inputs.cpu}}-${{inputs.raytracing_label}}-${{inputs.egl_label == 'egl' && 'headless' || 'desktop'}}

--- a/.github/actions/f3d-superbuild/action.yml
+++ b/.github/actions/f3d-superbuild/action.yml
@@ -94,8 +94,6 @@ runs:
       -DCMAKE_C_COMPILER_LAUNCHER=sccache
       -DENABLE_egl=${{ inputs.egl_label == 'egl' && 'ON' || 'OFF' }}
       -DENABLE_ospray=${{ inputs.raytracing_label == 'raytracing' && 'ON' || 'OFF' }}
-      -DENABLE_exodus=${{ contains(env.CMAKE_OSX_ARCHITECTURES, 'arm64') && 'OFF' || 'ON' }}
-      -DENABLE_openvdb=ON
       -DUSE_SYSTEM_python3=ON
       -Df3d_GIT_TAG=${{ inputs.f3d_version }}
       -Df3d_SOURCE_SELECTION=git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,6 @@ jobs:
 
     runs-on: ${{matrix.macos}}
 
-    env:
-      CMAKE_OSX_ARCHITECTURES: ${{matrix.cpu}}
-
     steps:
 
     - name: Checkout
@@ -94,6 +91,7 @@ jobs:
       with:
         f3d_version: origin/master
         raytracing_label: ${{matrix.raytracing_label}}
+        cpu: ${{matrix.cpu}}
 
   python_wheels:
     strategy:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -145,9 +145,6 @@ jobs:
 
     runs-on: ${{matrix.macos}}
 
-    env:
-      CMAKE_OSX_ARCHITECTURES: ${{matrix.cpu}}
-
     steps:
 
     - name: Checkout
@@ -162,6 +159,7 @@ jobs:
       with:
         f3d_version: ${{ needs.check_nightly.outputs.f3d_sha}}
         raytracing_label: ${{matrix.raytracing_label}}
+        cpu: ${{matrix.cpu}}
 
     - name: Delete previous nightly release assets
       uses: mknejp/delete-release-assets@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,9 +117,6 @@ jobs:
 
     runs-on: ${{matrix.macos}}
 
-    env:
-      CMAKE_OSX_ARCHITECTURES: ${{matrix.cpu}}
-
     steps:
 
     - name: Checkout
@@ -135,6 +132,7 @@ jobs:
       with:
         f3d_version: ${{github.event.inputs.f3d_version}}
         raytracing_label: ${{matrix.raytracing_label}}
+        cpu: ${{matrix.cpu}}
 
     - name: Publish assets
       if: ${{ github.event.inputs.publish_assets == 'true' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ function (superbuild_add_packaging)
 
 endfunction ()
 
-if (${CMAKE_OSX_ARCHITECTURES} MATCHES "arm64")
+if (${CMAKE_OSX_ARCHITECTURES} MATCHES "arm64" OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64")
   set(boost_extra_options
       architecture=arm)
 endif ()


### PR DESCRIPTION
 - Add EXODUS support
 - Remove not needed usage of CMAKE_OSX_ARCHITECTURE
 - Cross-compilation is still suported but not tested anymore