### PR TITLE
Update CI build wheel, skip Python 3.8 and macos x86_64 and add Python 3.13

### DIFF
--- a/.github/actions/wheels/action.yml
+++ b/.github/actions/wheels/action.yml
@@ -83,7 +83,7 @@ runs:
     if: |
       steps.cache-fsb.outputs.cache-hit != 'true' ||
       inputs.use_cache != 'true'
-    uses: pypa/cibuildwheel@v2.16.5
+    uses: pypa/cibuildwheel@v2.22.0
     with:
       package-dir: ${{github.workspace}}/f3d
       output-dir: ${{github.workspace}}/wheelhouse
@@ -114,7 +114,7 @@ runs:
     if: |
       steps.cache-fsb.outputs.cache-hit == 'true' &&
       inputs.use_cache == 'true'
-    uses: pypa/cibuildwheel@v2.16.5
+    uses: pypa/cibuildwheel@v2.22.0
     with:
       package-dir: ${{github.workspace}}/f3d
       output-dir: ${{github.workspace}}/wheelhouse

--- a/.github/actions/wheels/action.yml
+++ b/.github/actions/wheels/action.yml
@@ -90,7 +90,7 @@ runs:
       config-file: ${{github.workspace}}/f3d/pyproject.toml
     env:
       # TODO: cross-compile ARM and PyPy too
-      CIBW_SKIP: '*-musl* cp37-* pp*'
+      CIBW_SKIP: '*-musl* cp37-* cp38-* pp*'
       CIBW_ARCHS: native
       CIBW_BUILD_VERBOSITY: 1
       CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/f3d-app/f3d-wheels-manylinux-ci
@@ -120,7 +120,7 @@ runs:
       output-dir: ${{github.workspace}}/wheelhouse
       config-file: ${{github.workspace}}/f3d/pyproject.toml
     env:
-      CIBW_SKIP: '*-musl* cp37-* pp*'
+      CIBW_SKIP: '*-musl* cp37-* cp38-* pp*'
       CIBW_ARCHS: native
       CIBW_BUILD_VERBOSITY: 1
       CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/f3d-app/f3d-wheels-manylinux-ci

--- a/.github/actions/wheels/build_f3d_superbuild.sh
+++ b/.github/actions/wheels/build_f3d_superbuild.sh
@@ -2,7 +2,7 @@
 cmake -S ./source -B ./fsbb           \
   -DBUILD_SHARED_LIBS=OFF             \
   -DCMAKE_BUILD_TYPE=Release          \
-  -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0  \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 \
   -DENABLE_f3d=OFF                    \
   -DENABLE_alembic=ON                 \
   -DENABLE_assimp=ON                  \

--- a/.github/actions/wheels/build_f3d_superbuild.sh
+++ b/.github/actions/wheels/build_f3d_superbuild.sh
@@ -2,7 +2,7 @@
 cmake -S ./source -B ./fsbb           \
   -DBUILD_SHARED_LIBS=OFF             \
   -DCMAKE_BUILD_TYPE=Release          \
-  -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0  \
   -DENABLE_f3d=OFF                    \
   -DENABLE_alembic=ON                 \
   -DENABLE_assimp=ON                  \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -214,7 +214,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
 - Update CI build wheel action (which add python 3.13)
 - Skip python 3.8 as it is now EOL
 - Switch to macOS arm only wheel because of https://github.com/pypa/cibuildwheel/issues/2115 (will open an issue)