### PR TITLE
ospray: Use 2.12.0 for building binaries

### DIFF
--- a/.github/actions/f3d-superbuild/action.yml
+++ b/.github/actions/f3d-superbuild/action.yml
@@ -108,7 +108,7 @@ runs:
     shell: bash
     run: |
       cmake ./
-      ctest -R cpack --no-tests=error --output-on-failure -VV
+      ctest -R cpack --no-tests=error --output-on-failure
       ctest -R extract --no-tests=error --output-on-failure
 
   - name: Clean install

--- a/.github/actions/f3d-superbuild/action.yml
+++ b/.github/actions/f3d-superbuild/action.yml
@@ -84,7 +84,7 @@ runs:
       -DUSE_SYSTEM_python3=ON
       -Df3d_GIT_TAG=${{ inputs.f3d_version }}
       -Df3d_SOURCE_SELECTION=git
-      -Dospray_SOURCE_SELECTION=2.7.1
+      -Dospray_SOURCE_SELECTION=2.12.0
       -Dvtk_GIT_TAG=${{ env.VTK_COMMIT_SHA }}
       -Dvtk_SOURCE_SELECTION=git
       ${{ runner.os == 'Linux' && '-DENABLE_egl=ON -DENABLE_osmesa=ON' || null }}

--- a/.github/actions/f3d-superbuild/action.yml
+++ b/.github/actions/f3d-superbuild/action.yml
@@ -108,7 +108,7 @@ runs:
     shell: bash
     run: |
       cmake ./
-      ctest -R cpack --no-tests=error --output-on-failure
+      ctest -R cpack --no-tests=error --output-on-failure -VV
       ctest -R extract --no-tests=error --output-on-failure
 
   - name: Clean install

--- a/.github/actions/wheels/action.yml
+++ b/.github/actions/wheels/action.yml
@@ -41,7 +41,7 @@ runs:
     uses: actions/cache@v4
     with:
       path: fsbb/install
-      key: fsbb-${{runner.os}}-${{env.VTK_COMMIT_SHA}}-5
+      key: fsbb-${{runner.os}}-${{env.VTK_COMMIT_SHA}}-6
 
   - name: Setup Ninja Windows
     if: runner.os == 'Windows'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,6 @@ set(_superbuild_default_ospray ON)
 set(_superbuild_default_pybind11 OFF)
 set(_superbuild_default_tbb ON)
 set(_superbuild_default_openusd ON)
-set(_superbuild_ospray_default_selection "2.7.1")
 
 if (NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/superbuild/CMakeLists.txt")
   message(FATAL_ERROR "It appears as though the superbuild infrastructure "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,14 +104,16 @@ function (superbuild_add_packaging)
       TXZ
       DEB)
   endif ()
+
+  list(APPEND superbuild_export_variables
+    ospray_SOURCE_SELECTION)
+
   foreach (generator IN LISTS generators)
     superbuild_add_extra_package_test(f3d "${generator}"
       LABELS  "F3D"
       TIMEOUT 6400)
   endforeach ()
 
-  list(APPEND superbuild_export_variables
-    ospray_SOURCE_SELECTION)
 endfunction ()
 
 function (superbuild_add_tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,8 @@ function (superbuild_add_packaging)
       TIMEOUT 6400)
   endforeach ()
 
+  list(APPEND superbuild_export_variables
+    ospray_SOURCE_SELECTION)
 endfunction ()
 
 function (superbuild_add_tests)

--- a/projects/apple/f3d.bundle.cmake
+++ b/projects/apple/f3d.bundle.cmake
@@ -13,8 +13,17 @@ if (ospray_enabled)
     openvkl_module_cpu_device_4
     openvkl_module_cpu_device_8
     openvkl_module_cpu_device_16
-    ospray_module_denoiser
-    ospray_module_ispc)
+    ospray_module_denoiser)
+
+
+  if (ospray_SOURCE_SELECTION STREQUAL "2.12.0")
+    list(APPEND osprayextra_libraries
+      ispcrt_device_cpu
+      ospray_module_cpu)
+  else ()
+    list(APPEND osprayextra_libraries
+      ospray_module_ispc)
+  endif ()
 
   foreach (osprayextra_library IN LISTS osprayextra_libraries)
     if (EXISTS "${superbuild_install_location}/lib/lib${osprayextra_library}.dylib")

--- a/projects/unix/f3d.bundle.cmake
+++ b/projects/unix/f3d.bundle.cmake
@@ -18,7 +18,7 @@ if (ospray_enabled)
 
   if (ospray_SOURCE_SELECTION STREQUAL "2.12.0")
     list(APPEND osprayextra_libraries
-#ispcrt_device_cpu TODO
+      ispcrt_device_cpu
       openvkl_module_cpu_device_4
       openvkl_module_cpu_device_8
       openvkl_module_cpu_device_16

--- a/projects/unix/f3d.bundle.cmake
+++ b/projects/unix/f3d.bundle.cmake
@@ -16,6 +16,15 @@ if (ospray_enabled)
     openvkl_module_cpu_device
     ospray_module_denoiser)
 
+  if (ospray_SOURCE_SELECTION STREQUAL "2.12.0")
+    list(APPEND osprayextra_libraries
+      ispcrt_device_cpu
+      openvkl_module_cpu_device_4
+      openvkl_module_cpu_device_8
+      openvkl_module_cpu_device_16
+      ospray_module_cpu)
+  endif ()
+
   foreach (osprayextra_library IN LISTS osprayextra_libraries)
     file(GLOB lib_filenames
       RELATIVE "${superbuild_install_location}/lib"

--- a/projects/unix/f3d.bundle.cmake
+++ b/projects/unix/f3d.bundle.cmake
@@ -18,7 +18,7 @@ if (ospray_enabled)
 
   if (ospray_SOURCE_SELECTION STREQUAL "2.12.0")
     list(APPEND osprayextra_libraries
-      ispcrt_device_cpu
+#ispcrt_device_cpu TODO
       openvkl_module_cpu_device_4
       openvkl_module_cpu_device_8
       openvkl_module_cpu_device_16

--- a/projects/win32/f3d.bundle.cmake
+++ b/projects/win32/f3d.bundle.cmake
@@ -22,12 +22,20 @@ superbuild_windows_install_plugin("F3DShellExtension.dll" "bin" "bin"
 # Package supplemental ospray libraries that may be loaded dynamically
 if (ospray_enabled)
   set(osprayextra_libraries
-    openvkl_module_cpu_device
-    openvkl_module_cpu_device_4
-    openvkl_module_cpu_device_8
-    openvkl_module_cpu_device_16
-    ospray_module_denoiser
-    ospray_module_ispc)
+      openvkl_module_cpu_device
+      openvkl_module_cpu_device_4
+      openvkl_module_cpu_device_8
+      openvkl_module_cpu_device_16
+      ospray_module_denoiser)
+
+  if (ospray_SOURCE_SELECTION STREQUAL "2.12.0")
+    list(APPEND osprayextra_libraries
+         ispcrt_device_cpu
+         ospray_module_cpu)
+  else ()
+  list(APPEND osprayextra_libraries
+       ospray_module_ispc)
+  endif ()
 
   foreach (osprayextra_library IN LISTS osprayextra_libraries)
     superbuild_windows_install_plugin("${osprayextra_library}.dll" "bin" "bin"

--- a/projects/win32/f3d.bundle.cmake
+++ b/projects/win32/f3d.bundle.cmake
@@ -33,8 +33,8 @@ if (ospray_enabled)
          ispcrt_device_cpu
          ospray_module_cpu)
   else ()
-  list(APPEND osprayextra_libraries
-       ospray_module_ispc)
+    list(APPEND osprayextra_libraries
+         ospray_module_ispc)
   endif ()
 
   foreach (osprayextra_library IN LISTS osprayextra_libraries)

--- a/testing/baselines/TestOSPRay.png
+++ b/testing/baselines/TestOSPRay.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:55d3f0e304a19a57010de9f1bf439e8c1638cf41c6d4fd4ed162cdf4734c3f20
-size 28284
+oid sha256:d15df8fc97cfe7a0d55162974561839b9823226bd8e7e71a5720937b436bad53
+size 30444

--- a/versions.cmake
+++ b/versions.cmake
@@ -8,6 +8,8 @@ superbuild_set_revision(draco
   DOWNLOAD_NAME draco-1.5.7.tar.gz
   URL_MD5 b91def257264152be35c62f82f805d25)
 
+# Force embree to 4.2.0 when using OSPRay 2.12.0 because of
+# https://github.com/f3d-app/f3d-superbuild/issues/260
 superbuild_set_selectable_source(embree
   # https://github.com/embree/embree/releases
   SELECTS_WITH ospray

--- a/versions.cmake
+++ b/versions.cmake
@@ -8,6 +8,16 @@ superbuild_set_revision(draco
   DOWNLOAD_NAME draco-1.5.7.tar.gz
   URL_MD5 b91def257264152be35c62f82f805d25)
 
+superbuild_set_selectable_source(embree
+  # https://github.com/embree/embree/releases
+  SELECTS_WITH ospray
+  SELECT 2.7.1
+    URL     "https://www.paraview.org/files/dependencies/embree-v3.13.1.tar.gz"
+    URL_MD5 71453f1e9af48a95090112e493982898
+  SELECT 2.12.0
+    URL     "https://www.paraview.org/files/dependencies/embree-4.2.0.tar.gz"
+    URL_MD5 9e6abbfb230a2ea07e80fa193ed94186)
+
 superbuild_set_revision(imgui
   URL "https://github.com/ocornut/imgui/archive/refs/tags/v1.92.1.tar.gz"
   DOWNLOAD_NAME imgui-v1.92.1.tar.gz

--- a/versions.cmake
+++ b/versions.cmake
@@ -8,15 +8,9 @@ superbuild_set_revision(draco
   DOWNLOAD_NAME draco-1.5.7.tar.gz
   URL_MD5 b91def257264152be35c62f82f805d25)
 
-# Force embree to 4.2.0 when using OSPRay 2.12.0 because of
+# Force embree to 4.2.0 because of
 # https://github.com/f3d-app/f3d-superbuild/issues/260
-superbuild_set_selectable_source(embree
-  # https://github.com/embree/embree/releases
-  SELECTS_WITH ospray
-  SELECT 2.7.1
-    URL     "https://www.paraview.org/files/dependencies/embree-v3.13.1.tar.gz"
-    URL_MD5 71453f1e9af48a95090112e493982898
-  SELECT 2.12.0
+superbuild_set_revision(embree
     URL     "https://www.paraview.org/files/dependencies/embree-4.2.0.tar.gz"
     URL_MD5 9e6abbfb230a2ea07e80fa193ed94186)
 


### PR DESCRIPTION
 - Use OSPRay 2.12.0 instead of 2.7.0
 - Update common superbuild for ispc fix
 - Downgrade embree to 4.2.0
 - Add OSPRay 2.12.0 packaging support
 - Update baseline for 2.12.0
 - Force wheel cache rebuild