### PR TITLE
CI: Force windows 2022 instead of latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         raytracing_label: [raytracing, no-raytracing]
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
 
@@ -122,7 +122,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-2022, macos-latest]
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,7 +58,7 @@ jobs:
       matrix:
         raytracing_label: [raytracing, no-raytracing]
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
 
@@ -214,7 +214,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-2022, macos-latest]
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         raytracing_label: [raytracing, no-raytracing]
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
 
@@ -179,7 +179,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-2022, macos-latest]
 
     runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
Temporary fix for https://github.com/f3d-app/f3d-superbuild/issues/261