### PR TITLE
Bump cibuildwheel and disable repair on Windows

### DIFF
--- a/.github/actions/wheels/action.yml
+++ b/.github/actions/wheels/action.yml
@@ -88,7 +88,7 @@ runs:
     if: |
       steps.cache-fsb.outputs.cache-hit != 'true' ||
       inputs.use_cache != 'true'
-    uses: pypa/cibuildwheel@v3.4.1
+    uses: pypa/cibuildwheel@v4.1.1
     with:
       package-dir: ${{github.workspace}}/f3d
       output-dir: ${{github.workspace}}/wheelhouse
@@ -98,6 +98,7 @@ runs:
       CIBW_SKIP: '*-musl* cp38-* cp39-* pp*'
       CIBW_ARCHS: native
       CIBW_BUILD_VERBOSITY: 1
+      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ''
       CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/f3d-app/f3d-wheels-manylinux-ci
       CIBW_ENVIRONMENT: CMAKE_POLICY_VERSION_MINIMUM=3.5 MACOSX_DEPLOYMENT_TARGET=14.0
       CIBW_ENVIRONMENT_PASS_LINUX: >
@@ -120,7 +121,7 @@ runs:
     if: |
       steps.cache-fsb.outputs.cache-hit == 'true' &&
       inputs.use_cache == 'true'
-    uses: pypa/cibuildwheel@v3.4.1
+    uses: pypa/cibuildwheel@v4.1.1
     with:
       package-dir: ${{github.workspace}}/f3d
       output-dir: ${{github.workspace}}/wheelhouse
@@ -129,6 +130,7 @@ runs:
       CIBW_SKIP: '*-musl* cp38-* cp39-* pp*'
       CIBW_ARCHS: native
       CIBW_BUILD_VERBOSITY: 1
+      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ''
       CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/f3d-app/f3d-wheels-manylinux-ci
       CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=14.0
       CIBW_ENVIRONMENT_PASS_LINUX: >


### PR DESCRIPTION
https://cibuildwheel.pypa.io/en/stable/options/#repair-wheel-command

> Since cibuildwheel 4.0, delvewheel is the default repair-wheel-command on Windows, so extension-module DLLs are bundled automatically. If a wheel has a platform tag but contains no extension module (for example, a package that sets a platform tag but ships a pre-built DLL itself), delvewheel may error. In that case, set repair-wheel-command = "" to skip the repair step.